### PR TITLE
Ensure product names are in English

### DIFF
--- a/Sources/Data/OpenFoodFactsDTO.swift
+++ b/Sources/Data/OpenFoodFactsDTO.swift
@@ -7,11 +7,15 @@ struct SearchResponseDTO: Decodable {
 struct ProductDTO: Decodable {
   let id: String
   let productName: String?
+  let productNameEn: String?
+  let genericNameEn: String?
   let nutriments: NutrimentsDTO?
 
   enum CodingKeys: String, CodingKey {
     case id = "_id"
     case productName = "product_name"
+    case productNameEn = "product_name_en"
+    case genericNameEn = "generic_name_en"
     case nutriments
   }
 }


### PR DESCRIPTION
## Summary
- fetch `product_name_en` and `generic_name_en` from OpenFoodFacts
- fall back to English names when available and trim whitespace

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_b_6870334512c4832b816cd0b5d19de066