### PR TITLE
Add LLM powered food search

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ let client = URLLLMClient(url: URL(string: "https://api.example.com/model")!,
 UITestHarnessView(service: LLMFoodSearchRepository(client: client))
 ```
 
+`URLLLMClient` will also read a HuggingFace token from the `HF_API_TOKEN` environment
+variable if no `Authorization` header is supplied. Set this variable to avoid 401
+errors with the default endpoint.
+
 Non-2xx responses are printed to the console with their HTTP status code and body to aid debugging.
 
 Run `swift build` and `swift test` to verify.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CalorieCounterSDK
 
-A lightweight Swift Package that provides simple calorie counting features with data powered by Open Food Facts. Supports iOS 15+ and Swift 6.1.
+A lightweight Swift Package that provides simple calorie counting features. Food information can come from any language model conforming to `LLMClient` and by default uses a free HuggingFace endpoint. Supports iOS 15+ and Swift 6.1.
 
 ## Integration
 
@@ -18,6 +18,17 @@ import CalorieCounterSDK
 #if DEBUG
 CalorieCounterSDK.UITestHarnessView()
 #endif
+```
+
+### Customising the LLM
+
+`UITestHarnessView` uses `LLMFoodSearchRepository` with a `URLLLMClient` by default.
+You can swap in any `LLMClient` implementation to experiment with different
+models:
+
+```swift
+let client = URLLLMClient(url: URL(string: "https://api.example.com/model")!)
+UITestHarnessView(service: LLMFoodSearchRepository(client: client))
 ```
 
 Run `swift build` and `swift test` to verify.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ CalorieCounterSDK.UITestHarnessView()
 ### Customising the LLM
 
 `UITestHarnessView` uses `LLMFoodSearchRepository` with a `URLLLMClient` by default.
-You can swap in any `LLMClient` implementation to experiment with different
-models:
+If your chosen model requires an API token, pass any extra HTTP headers to the client:
 
 ```swift
-let client = URLLLMClient(url: URL(string: "https://api.example.com/model")!)
+let headers = ["Authorization": "Bearer YOUR_TOKEN"]
+let client = URLLLMClient(url: URL(string: "https://api.example.com/model")!,
+                          headers: headers)
 UITestHarnessView(service: LLMFoodSearchRepository(client: client))
 ```
+
+Non-2xx responses are printed to the console with their HTTP status code and body to aid debugging.
 
 Run `swift build` and `swift test` to verify.

--- a/Sources/Data/LLMClient.swift
+++ b/Sources/Data/LLMClient.swift
@@ -26,13 +26,27 @@ public struct URLLLMClient: LLMClient, @unchecked Sendable {
     request.allHTTPHeaderFields = headers.merging(["Content-Type": "application/json"]) { $1 }
 
     let (data, response) = try await session.data(for: request)
-    guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+    guard let http = response as? HTTPURLResponse else {
       throw URLError(.badServerResponse)
+    }
+    if !(200..<300).contains(http.statusCode) {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      print("[URLLLMClient] HTTP \(http.statusCode) error: \(body)")
+      throw HTTPError(statusCode: http.statusCode, body: body)
     }
 
     guard let text = String(data: data, encoding: .utf8) else {
       throw URLError(.cannotDecodeContentData)
     }
     return text
+  }
+}
+
+public struct HTTPError: LocalizedError {
+  public let statusCode: Int
+  public let body: String
+
+  public var errorDescription: String? {
+    "HTTP \(statusCode): \(body)"
   }
 }

--- a/Sources/Data/LLMClient.swift
+++ b/Sources/Data/LLMClient.swift
@@ -11,12 +11,16 @@ public protocol LLMClient: Sendable {
 public struct URLLLMClient: LLMClient, @unchecked Sendable {
   private let url: URL
   private let session: URLSession
-  private let headers: [String: String]
+  private var headers: [String: String]
 
   public init(url: URL, headers: [String: String] = [:], session: URLSession = .shared) {
     self.url = url
     self.headers = headers
     self.session = session
+
+    if headers["Authorization"] == nil, let token = ProcessInfo.processInfo.environment["HF_API_TOKEN"], !token.isEmpty {
+      self.headers["Authorization"] = "Bearer \(token)"
+    }
   }
 
   public func send(prompt: String) async throws -> String {

--- a/Sources/Data/LLMClient.swift
+++ b/Sources/Data/LLMClient.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol LLMClient: Sendable {
+  func send(prompt: String) async throws -> String
+}
+
+public struct URLLLMClient: LLMClient, @unchecked Sendable {
+  private let url: URL
+  private let session: URLSession
+  private let headers: [String: String]
+
+  public init(url: URL, headers: [String: String] = [:], session: URLSession = .shared) {
+    self.url = url
+    self.headers = headers
+    self.session = session
+  }
+
+  public func send(prompt: String) async throws -> String {
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = try JSONEncoder().encode(["inputs": prompt])
+    request.allHTTPHeaderFields = headers.merging(["Content-Type": "application/json"]) { $1 }
+
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+      throw URLError(.badServerResponse)
+    }
+
+    guard let text = String(data: data, encoding: .utf8) else {
+      throw URLError(.cannotDecodeContentData)
+    }
+    return text
+  }
+}

--- a/Sources/Data/LLMFoodSearchRepository.swift
+++ b/Sources/Data/LLMFoodSearchRepository.swift
@@ -1,0 +1,34 @@
+import Domain
+import Foundation
+
+public struct LLMFoodSearchRepository: FoodSearchService, Sendable {
+  private let client: LLMClient
+  private let jsonDecoder: JSONDecoder = JSONDecoder()
+
+  public init(client: LLMClient) {
+    self.client = client
+  }
+
+  public func search(query: String) async throws -> [FoodItem] {
+    let prompt = """
+    You are a nutrition assistant. When given a food search query, reply ONLY in JSON with an array called items. Each item must contain a name and caloriesPer100g integer. Example:\n{"items":[{"name":"Apple","caloriesPer100g":52}]}. If you are unsure of the calories, skip that food.
+    Query: \(query)
+    """
+
+    let responseText = try await client.send(prompt: prompt)
+    let data = Data(responseText.utf8)
+    let result = try jsonDecoder.decode(LLMFoodResult.self, from: data)
+    return result.items.enumerated().map { idx, element in
+      FoodItem(id: "\(idx)-\(element.name)", name: element.name, caloriesPer100g: element.caloriesPer100g)
+    }
+  }
+}
+
+private struct LLMFoodResult: Decodable {
+  let items: [LLMFood]
+}
+
+private struct LLMFood: Decodable {
+  let name: String
+  let caloriesPer100g: Int
+}

--- a/Sources/Data/LLMFoodSearchRepository.swift
+++ b/Sources/Data/LLMFoodSearchRepository.swift
@@ -16,10 +16,17 @@ public struct LLMFoodSearchRepository: FoodSearchService, Sendable {
     """
 
     let responseText = try await client.send(prompt: prompt)
+    print("[LLMFoodSearchRepository] Raw response: \(responseText)")
+
     let data = Data(responseText.utf8)
-    let result = try jsonDecoder.decode(LLMFoodResult.self, from: data)
-    return result.items.enumerated().map { idx, element in
-      FoodItem(id: "\(idx)-\(element.name)", name: element.name, caloriesPer100g: element.caloriesPer100g)
+    do {
+      let result = try jsonDecoder.decode(LLMFoodResult.self, from: data)
+      return result.items.enumerated().map { idx, element in
+        FoodItem(id: "\(idx)-\(element.name)", name: element.name, caloriesPer100g: element.caloriesPer100g)
+      }
+    } catch {
+      print("[LLMFoodSearchRepository] Failed to decode response: \(error)")
+      throw error
     }
   }
 }

--- a/Sources/UITestHarness/UITestHarnessView.swift
+++ b/Sources/UITestHarness/UITestHarnessView.swift
@@ -27,10 +27,18 @@
             let svc = service
             isLoading = true
             Task {
-              let newResults = (try? await svc.search(query: q)) ?? []
-              await MainActor.run {
-                results = newResults
-                isLoading = false
+              do {
+                let newResults = try await svc.search(query: q)
+                await MainActor.run {
+                  results = newResults
+                  isLoading = false
+                }
+              } catch {
+                print("[UITestHarnessView] Search failed: \(error)")
+                await MainActor.run {
+                  results = []
+                  isLoading = false
+                }
               }
             }
           }

--- a/Tests/DataTests/LLMFoodSearchRepositoryTests.swift
+++ b/Tests/DataTests/LLMFoodSearchRepositoryTests.swift
@@ -15,6 +15,18 @@ final class LLMFoodSearchRepositoryTests: XCTestCase {
     XCTAssertEqual(items[1].name, "Banana")
     XCTAssertEqual(items[1].caloriesPer100g, 89)
   }
+
+  func testSearchThrowsForInvalidJSON() async {
+    let response = "{\"itemsz\":[]}" // malformed key
+    let client = MockLLMClient(response: response)
+    let repo = LLMFoodSearchRepository(client: client)
+    do {
+      _ = try await repo.search(query: "fruit")
+      XCTFail("Expected error")
+    } catch {
+      // success - error thrown
+    }
+  }
 }
 
 private struct MockLLMClient: LLMClient {

--- a/Tests/DataTests/LLMFoodSearchRepositoryTests.swift
+++ b/Tests/DataTests/LLMFoodSearchRepositoryTests.swift
@@ -1,0 +1,23 @@
+import Domain
+import XCTest
+
+@testable import Data
+
+final class LLMFoodSearchRepositoryTests: XCTestCase {
+  func testSearchParsesItems() async throws {
+    let response = "{" + "\"items\":[{\"name\":\"Apple\",\"caloriesPer100g\":52},{\"name\":\"Banana\",\"caloriesPer100g\":89}]}"
+    let client = MockLLMClient(response: response)
+    let repo = LLMFoodSearchRepository(client: client)
+    let items = try await repo.search(query: "fruit")
+    XCTAssertEqual(items.count, 2)
+    XCTAssertEqual(items[0].name, "Apple")
+    XCTAssertEqual(items[0].caloriesPer100g, 52)
+    XCTAssertEqual(items[1].name, "Banana")
+    XCTAssertEqual(items[1].caloriesPer100g, 89)
+  }
+}
+
+private struct MockLLMClient: LLMClient {
+  let response: String
+  func send(prompt: String) async throws -> String { response }
+}


### PR DESCRIPTION
## Summary
- add `LLMClient` abstraction and `URLLLMClient` implementation
- implement `LLMFoodSearchRepository` using an LLM prompt
- show a loading indicator in `UITestHarnessView`
- change default search service to use the LLM
- document how to customise the client
- test the new repository

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68711b9873d8832bbe2fc3064ce02cd1